### PR TITLE
Use /help/ as default value for base href in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "angular-cli": {},
   "scripts": {
     "ng": "ng",
-    "build": "ng build",
-    "prod": "ng build --prod --base-href /help/",
+    "build": "ng build --base-href /help/",
     "start": "ng serve --port 4200 --base-href /help/",
     "lint": "eslint . --ext js,ts",
     "test": "ng test --watch=false",


### PR DESCRIPTION
- any --base-href value provided from the terminal will override this default

ie npm run build --base-href /other/ will result in /help/ being effectively replaced by /other/